### PR TITLE
Feature/flip arrays

### DIFF
--- a/src/combinations.jl
+++ b/src/combinations.jl
@@ -45,19 +45,20 @@ and `n_way` is the order of the combinations, most commonly 2-way.
 """
 function all_combinations(arity, n_way)
     v_cnt = length(arity)
+    # This returns a list of lists, so it has length, not size.
     indices = collect(combinations(1:v_cnt, n_way))
     combinations_cnt = total_combinations(arity, n_way)
 
-    coverage = zeros(eltype(arity), combinations_cnt, v_cnt)
+    coverage = zeros(eltype(arity), v_cnt, combinations_cnt)
     idx = 1
-    for indices_idx in 1:size(indices, 1)
+    for indices_idx in 1:length(indices)
         offset = indices[indices_idx]
         sub_arity = arity[offset]
         sub_cnt = prod(sub_arity)
         values = copy(sub_arity)
         for sub_idx in 1:sub_cnt
             next_multiplicative!(values, sub_arity)
-            coverage[idx, offset] = values
+            coverage[offset, idx] = values
             idx += 1
         end
     end
@@ -80,17 +81,17 @@ function one_parameter_combinations(arity, n_way)
     param_cnt = length(arity)
     if n_way > 1
         partial = all_combinations(arity[1:(param_cnt-1)], n_way - 1)
-        one_set = size(partial, 1)
-        comb = zeros(eltype(arity), one_set * arity[param_cnt], param_cnt)
+        one_set = size(partial, 2)
+        comb = zeros(eltype(arity), param_cnt, one_set * arity[param_cnt])
         for vidx in 1:(arity[param_cnt])
-            row_begin = (vidx - 1) * one_set + 1
-            row_end = vidx * one_set
-            comb[row_begin:row_end, 1:size(partial, 2)] .= partial
-            comb[row_begin:row_end, param_cnt] .= vidx
+            col_begin = (vidx - 1) * one_set + 1
+            col_end = vidx * one_set
+            comb[1:size(partial, 1), col_begin:col_end] .= partial
+            comb[param_cnt, col_begin:col_end] .= vidx
         end
     else  # n_way == 1
-        comb = zeros(eltype(arity), arity[param_cnt], param_cnt)
-        comb[:, param_cnt] .= 1:(arity[param_cnt])
+        comb = zeros(eltype(arity), param_cnt, arity[param_cnt])
+        comb[param_cnt, :] .= 1:(arity[param_cnt])
     end
     comb
 end
@@ -102,12 +103,12 @@ combination_number(n, m) = prod(n:-1:(n-m+1)) ÷ factorial(m)
 function pairs_in_entry(entry, n_way)
     n = length(entry)
     ans = zeros(Int, combination_number(n, n_way), n)
-    row_idx = 1
+    col_set_idx = 1
     for param_idx in combinations(1:length(entry), n_way)
-        for col_idx in 1:n_way
-            ans[row_idx, param_idx[col_idx]] = entry[param_idx[col_idx]]
+        for row_idx in 1:n_way
+            ans[param_idx[row_idx], col_set_idx] = entry[param_idx[row_idx]]
         end
-        row_idx += 1
+        col_set_idx += 1
     end
     ans
 end

--- a/src/coverage_set.jl
+++ b/src/coverage_set.jl
@@ -367,7 +367,7 @@ deletes them.
 """
 function remove_combinations!(mc::MatrixCoverage, disallow)
     allow_cnt = 0
-    allowed = zeros(Int, size(mc.allc, 1))
+    allowed = zeros(Int, size(mc.allc, 2))
     for i in 1:size(mc.allc, 2)
         if !disallow(mc.allc[:, i])
             allow_cnt += 1

--- a/src/coverage_set.jl
+++ b/src/coverage_set.jl
@@ -9,7 +9,7 @@ import Base: eltype
 
 """
 Represents covered tuples using a two-dimensional matrix.
-Each row is another tuple to cover. Each column is a parameter.
+Each column is another tuple to cover. Each row is a parameter.
 A zero means this parameter is not part of the tuple.
 The initial matrix represents all tuples to cover.
 The `remain` integer is the number of tuples left to cover.
@@ -51,8 +51,8 @@ values for each parameter, in order.
 function all_combinations_matrix(arity, n_way)
     allc = all_combinations(arity, n_way)
     # Every combination is nonzero.
-    @assert sum(sum(allc, dims = 2) == 0) == 0
-    remain = size(allc, 1)
+    @assert sum(sum(allc, dims = 1) == 0) == 0
+    remain = size(allc, 2)
     MatrixCoverage(allc, remain, arity)
 end
 
@@ -69,7 +69,7 @@ once for each possible value of the given parameter.
 """
 function one_parameter_combinations_matrix(arity, n_way)
     comb = one_parameter_combinations(arity, n_way)
-    MatrixCoverage(comb, size(comb, 1), arity)
+    MatrixCoverage(comb, size(comb, 2), arity)
 end
 
 
@@ -90,12 +90,12 @@ end
 
 
 function combination_histogram(allc, arity)
-    width = maximum(arity)
-    hist = zeros(Int, length(arity), width)
-    for row_idx in 1:size(allc, 1)
-        for col_idx in 1:width
-            if allc[row_idx, col_idx] > 0
-                hist[col_idx, allc[row_idx, col_idx]] += 1
+    height = maximum(arity)
+    hist = zeros(Int, height, length(arity))
+    for colh_idx in 1:size(allc, 2)
+        for rowh_idx in 1:height
+            if allc[rowh_idx, colh_idx] > 0
+                hist[allc[rowh_idx, colh_idx], rowh_idx] += 1
             end
         end
     end
@@ -103,8 +103,8 @@ function combination_histogram(allc, arity)
 end
 
 
-function most_to_cover(allc, row_cnt)
-   argmax(vec(sum(allc[1:row_cnt, :] .!= 0, dims = 1)))
+function most_to_cover(allc, col_cnt)
+   argmax(vec(sum(allc[:, 1:col_cnt] .!= 0, dims = 2)))
 end
 
 
@@ -117,7 +117,7 @@ of integers, where each value is the number of times that parameter
 appears in any uncovered tuple.
 """
 function coverage_by_parameter(mc::MatrixCoverage)
-    vec(sum(mc.allc[1:mc.remain, :] .!= 0, dims = 1))
+    vec(sum(mc.allc[:, 1:mc.remain] .!= 0, dims = 2))
 end
 
 
@@ -131,17 +131,17 @@ to cover so that we can address it first.
 """
 function coverage_by_value(mc, param_idx)
     hist = zeros(Int, mc.arity[param_idx] + 1)
-    for row_idx in 1:mc.remain
-        hist[mc.allc[row_idx, param_idx] + 1] += 1
+    for col_idx in 1:mc.remain
+        hist[mc.allc[param_idx, col_idx] + 1] += 1
     end
     hist[2:end]
 end
 
 
-function most_common_value(allc, row_cnt, arity, param_idx)
+function most_common_value(allc, col_cnt, arity, param_idx)
     hist = zeros(Int, arity[param_idx] + 1)
-    for row_idx in 1:row_cnt
-        hist[allc[row_idx, param_idx] + 1] += 1
+    for col_idx in 1:col_cnt
+        hist[allc[param_idx, col_idx] + 1] += 1
     end
     argmax(hist[2:end])
 end
@@ -171,21 +171,21 @@ function most_matches_existing(mc::MatrixCoverage, existing, param_idx)
     max_known = sum(existing .!= 0)
     # params_known = min(sum(existing .!= 0), n_way - 1)
     hist = zeros(Int, mc.arity[param_idx])
-    for row_idx in 1:mc.remain
+    for col_idx in 1:mc.remain
         # The given parameter column is part of this match.
-        if mc.allc[row_idx, param_idx] != 0
+        if mc.allc[param_idx, col_idx] != 0
             match_cnt = 0
             n_way = 0
             for match_idx in 1:param_cnt
-                if mc.allc[row_idx, match_idx] != 0
+                if mc.allc[match_idx, col_idx] != 0
                     n_way += 1
                 end
-                if existing[match_idx] != 0 && mc.allc[row_idx, match_idx] == existing[match_idx]
+                if existing[match_idx] != 0 && mc.allc[match_idx, col_idx] == existing[match_idx]
                     match_cnt += 1
                 end
             end
             if match_cnt == min(max_known, n_way)
-                hist[mc.allc[row_idx, param_idx]] += 1
+                hist[mc.allc[param_idx, col_idx]] += 1
             end
         end
     end
@@ -198,23 +198,23 @@ Given an entry in the test set that has missing values, which are
 zeros, find any matches that could be created by setting those
 missing values. Return a new version of the entry.
 """
-function matches_from_missing(mc::MatrixCoverage, entry, param_idx)
+function matches_from_missing(mc::MatrixCoverage, entry, missing_param)
     param_cnt = parameter_cnt(mc)
-    hist = zeros(eltype(mc), mc.arity[param_idx])
-    for row_idx in 1:mc.remain
-        if mc.allc[row_idx, param_idx] != 0
+    hist = zeros(eltype(mc), mc.arity[missing_param])
+    for tuple_idx in 1:mc.remain
+        if mc.allc[missing_param, tuple_idx] != 0
             found = true
-            for col_idx in 1:param_cnt
+            for param_idx in 1:param_cnt
                 if (
-                    entry[col_idx] !=0 &&
-                    mc.allc[row_idx, col_idx] != 0 &&
-                    entry[col_idx] != mc.allc[row_idx, col_idx]
+                    entry[param_idx] !=0 &&
+                    mc.allc[param_idx, tuple_idx] != 0 &&
+                    entry[param_idx] != mc.allc[param_idx, tuple_idx]
                 )
                     found = false
                 end
             end
             if found
-                hist[mc.allc[row_idx, param_idx]] += 1
+                hist[mc.allc[missing_param, tuple_idx]] += 1
             end
         end  # No matches unless the particular column is nonzero.
     end
@@ -228,9 +228,9 @@ end
 Find the first uncovered tuple for a particular parameter value.
 """
 function first_match_for_parameter(mc::MatrixCoverage, param_idx)
-    for row_idx in 1:mc.remain
-        if mc.allc[row_idx, param_idx] != 0
-            return mc.allc[row_idx, :]
+    for col_idx in 1:mc.remain
+        if mc.allc[param_idx, col_idx] != 0
+            return mc.allc[:, col_idx]
         end  # else keep looking
     end
     return zeros(eltype(mc), length(mc.arity))
@@ -245,18 +245,18 @@ that matches the existing values, in any order.
 """
 function fill_consistent_matches(mc::MatrixCoverage, entry)
     param_cnt = parameter_cnt(mc)
-    for row_idx in 1:mc.remain
+    for col_idx in 1:mc.remain
         found = true
-        for col_idx in 1:param_cnt
-            v = mc.allc[row_idx, col_idx]
-            if entry[col_idx] != 0 && v != 0 && v != entry[col_idx]
+        for param_idx in 1:param_cnt
+            v = mc.allc[param_idx, col_idx]
+            if entry[param_idx] != 0 && v != 0 && v != entry[param_idx]
                 found = false
             end
         end
         if found
             for copy_idx in 1:param_cnt
-                if mc.allc[row_idx, copy_idx] != 0
-                    entry[copy_idx] = mc.allc[row_idx, copy_idx]
+                if mc.allc[copy_idx, col_idx] != 0
+                    entry[copy_idx] = mc.allc[copy_idx, col_idx]
                 end
             end
         end
@@ -286,15 +286,15 @@ function add_coverage!(mc::MatrixCoverage, entry)
     covers = zeros(Int, mc.remain)
     cover_cnt = 0
     # Find matches before reordering them to the end.
-    for row_idx in 1:mc.remain
+    for col_idx in 1:mc.remain
         match_cnt = 0
         n_way = 0
         for match_idx in 1:param_cnt
-            if mc.allc[row_idx, match_idx] != 0
+            if mc.allc[match_idx, col_idx] != 0
                 n_way += 1
                 if (
                     entry[match_idx] != 0 &&
-                    mc.allc[row_idx, match_idx] == entry[match_idx]
+                    mc.allc[match_idx, col_idx] == entry[match_idx]
                 )
                     match_cnt += 1
                 end
@@ -302,16 +302,16 @@ function add_coverage!(mc::MatrixCoverage, entry)
         end
         if match_cnt == n_way
             cover_cnt += 1
-            covers[cover_cnt] = row_idx
+            covers[cover_cnt] = col_idx
         end
     end
     # Given the matches, we can swap them to the end of the matrix.
     # Work from the end in case a match is near row_cnt.
     for cover_idx in cover_cnt:-1:1
         if mc.remain > 1
-            save = mc.allc[mc.remain, :]
-            mc.allc[mc.remain, :] = mc.allc[covers[cover_idx], :]
-            mc.allc[covers[cover_idx], :] = save
+            save = mc.allc[:, mc.remain]
+            mc.allc[:, mc.remain] = mc.allc[:, covers[cover_idx]]
+            mc.allc[:, covers[cover_idx]] = save
             mc.remain -= 1
         else
             mc.remain -= 1
@@ -336,14 +336,14 @@ the match score by increasing the score for greater wayness.
 function match_score(mc::MatrixCoverage, entry)
     param_cnt = length(entry)
     cover_cnt = 0
-    for row_idx in 1:mc.remain
+    for col_idx in 1:mc.remain
         param_match_cnt = 0
         n_way = 0
         for match_idx in 1:param_cnt
-            if mc.allc[row_idx, match_idx] == entry[match_idx]
+            if mc.allc[match_idx, col_idx] == entry[match_idx]
                 param_match_cnt += 1
             end
-            if mc.allc[row_idx, match_idx] != 0
+            if mc.allc[match_idx, col_idx] != 0
                 n_way += 1
             end
         end
@@ -368,14 +368,14 @@ deletes them.
 function remove_combinations!(mc::MatrixCoverage, disallow)
     allow_cnt = 0
     allowed = zeros(Int, size(mc.allc, 1))
-    for i in 1:size(mc.allc, 1)
-        if !disallow(mc.allc[i, :])
+    for i in 1:size(mc.allc, 2)
+        if !disallow(mc.allc[:, i])
             allow_cnt += 1
             allowed[allow_cnt] = i
         # else disallowed
         end
     end
-    mc.allc = mc.allc[allowed[1:allow_cnt], :]
+    mc.allc = mc.allc[:, allowed[1:allow_cnt]]
     mc.remain = allow_cnt
 end
 
@@ -404,14 +404,14 @@ function multi_way_coverage(arity, wayness, base_wayness)
         # The parameter set is a list of parameter indices.
         for param_set in wayness[order]
             high_combos = all_combinations(arity[param_set], order)
-            widened = zeros(eltype(arity), size(high_combos, 1), param_cnt)
-            widened[:, param_set] = high_combos
+            widened = zeros(eltype(arity), param_cnt, size(high_combos, 2))
+            widened[param_set, :] = high_combos
             push!(order_combos, widened)
         end
         # We could remove duplicates of higher orders.
     end
     push!(order_combos, all_combinations(arity, base_wayness))
-    vcat(order_combos...)
+    hcat(order_combos...)
 end
 
 

--- a/src/parameter_order.jl
+++ b/src/parameter_order.jl
@@ -32,31 +32,31 @@ function ipog(arity, n_way)
     test_set = all_combinations(arity[1:n_way], n_way)
 
     for param_idx in (n_way + 1):param_cnt
-        wider = zeros(eltype(arity), size(test_set, 1), param_idx)
-        wider[:, 1:(param_idx - 1)] .= test_set
+        taller = zeros(eltype(arity), param_idx, size(test_set, 2))
+        taller[1:(param_idx - 1), :] .= test_set
 
         # Seed test cases by adding them once params are covered and not double-covering.
         # Make mixed strength here, once all params at a strength are covered.
         allc = one_parameter_combinations_matrix(arity[1:param_idx], n_way)
         # Exclude unwanted by stripping them from the allc combinations.
-        for set_row_idx in 1:size(wider, 1)
+        for set_col_idx in 1:size(taller, 2)
             # This needs to account for previous entries that aren't set.
-            match_hist = matches_from_missing(allc, wider[set_row_idx, :], param_idx)
+            match_hist = matches_from_missing(allc, taller[:, set_col_idx], param_idx)
             if (any(match_hist .> 0))
                 # The argmax tie-breaks in a consistent manner.
-                wider[set_row_idx, param_idx] = argmax(match_hist)
-                add_coverage!(allc, wider[set_row_idx, :])
+                taller[param_idx, set_col_idx] = argmax(match_hist)
+                add_coverage!(allc, taller[:, set_col_idx])
             end  # else don't set this entry by leaving it zero.
         end
 
-        for missing_row_idx in 1:size(wider, 1)
-            nonzero = sum(wider[missing_row_idx, 1:(param_idx - 1)] .> 0)
+        for missing_col_idx in 1:size(taller, 2)
+            nonzero = sum(taller[1:(param_idx - 1), missing_col_idx] .> 0)
             if nonzero < param_idx - 1
                 # The found_values has what format?
-                found_entry = fill_consistent_matches(allc, wider[missing_row_idx, :])
+                found_entry = fill_consistent_matches(allc, taller[:, missing_col_idx])
                 remain_zero = sum(found_entry .> 0)
                 if remain_zero < nonzero
-                    wider[missing_row_idx, :] .= found_entry
+                    taller[:, missing_col_idx] .= found_entry
                     add_coverage!(allc, found_entry)
                 end  # else nothing found for this row.
             end
@@ -71,32 +71,32 @@ function ipog(arity, n_way)
             push!(add_entries, filled)
         end
 
-        test_set = zeros(eltype(arity), size(wider, 1) + length(add_entries), param_idx)
-        test_set[1:size(wider, 1), :] .= wider
+        test_set = zeros(eltype(arity), param_idx, size(taller, 2) + length(add_entries))
+        test_set[:, 1:size(taller, 2)] .= taller
         for long_idx in 1:length(add_entries)
-            test_set[size(wider, 1) + long_idx, :] .= add_entries[long_idx]
+            test_set[:, size(taller, 2) + long_idx] .= add_entries[long_idx]
         end
     end
 
     # We could have zero values at the end, so fill them in with the
     # least-used values.
     hist = zeros(Int, param_cnt, maximum(arity))
-    for hist_row in 1:size(test_set, 1)
-        for hist_col in 1:size(test_set, 2)
-            if test_set[hist_row, hist_col] > 0
-                hist[hist_col, test_set[hist_row, hist_col]] += 1
+    for hist_entry in 1:size(test_set, 2)
+        for hist_param in 1:size(test_set, 1)
+            if test_set[hist_param, hist_entry] > 0
+                hist[hist_param, test_set[hist_param, hist_entry]] += 1
             end
         end
     end
-    for fill_row in 1:size(test_set, 1)
-        for fill_col in 1:size(test_set, 2)
-            if test_set[fill_row, fill_col] == 0
-                fill_val = argmin(hist[fill_col, 1:arity[fill_col]])
-                test_set[fill_row, fill_col] = fill_val
-                hist[fill_col, fill_val] += 1
+    for fill_col in 1:size(test_set, 2)
+        for fill_param in 1:size(test_set, 1)
+            if test_set[fill_param, fill_col] == 0
+                fill_val = argmin(hist[fill_param, 1:arity[fill_param]])
+                test_set[fill_param, fill_col] = fill_val
+                hist[fill_param, fill_val] += 1
             end
         end
     end
     # reorder test columns with `original_order`.
-    test_set[:, original_order]
+    test_set[original_order, :]
 end

--- a/test/test_combinations.jl
+++ b/test/test_combinations.jl
@@ -46,19 +46,19 @@ for ac_trial_idx in 1:5
     arity = rand(rng, 2:4, param_cnt)
     coverage = UnitTestDesign.all_combinations(arity, n_way)
     # It has the right column dimnsion.
-    @test size(coverage, 2) == length(arity)
+    @test size(coverage, 1) == length(arity)
     # Every combination is nonzero.
-    @test sum(sum(coverage, dims = 2) == 0) == 0
+    @test sum(sum(coverage, dims = 1) == 0) == 0
     # The total number of combinations agrees with expectations.
-    @test UnitTestDesign.total_combinations(arity, n_way) == size(coverage, 1)
+    @test UnitTestDesign.total_combinations(arity, n_way) == size(coverage, 2)
     # Generate some random combinations and check that they are in there.
     for comb_idx in 1:100
         comb = [rand(rng, 1:arity[cj]) for cj in 1:param_cnt]
         comb[randperm(rng, param_cnt)[1:(param_cnt - n_way)]] .= 0
         @test sum(comb .!= 0) == n_way
         found = false
-        for sidx in 1:size(coverage, 1)
-            if coverage[sidx, :] == comb
+        for sidx in 1:size(coverage, 2)
+            if coverage[:, sidx] == comb
                 found = true
             end
         end
@@ -70,21 +70,21 @@ end
 ### one_parameter_combinations(arity, n_way)
 
 minimal = UnitTestDesign.one_parameter_combinations([2, 3], 1)
-@test minimal == [0 1; 0 2; 0 3]
+@test minimal == [0 1; 0 2; 0 3]'
 
 paired = UnitTestDesign.one_parameter_combinations([2, 3], 2)
-@test paired == [1 1; 2 1; 1 2; 2 2; 1 3; 2 3]
+@test paired == [1 1; 2 1; 1 2; 2 2; 1 3; 2 3]'
 
 singled = UnitTestDesign.one_parameter_combinations([2, 2, 3], 2)
 @test singled == [
     1 0 1; 2 0 1; 0 1 1; 0 2 1;
     1 0 2; 2 0 2; 0 1 2; 0 2 2;
     1 0 3; 2 0 3; 0 1 3; 0 2 3
-    ]
+    ]'
 
 again = UnitTestDesign.one_parameter_combinations([2, 2, 3], 3)
 @test again == [
     1 1 1; 1 2 1; 2 1 1; 2 2 1;
     1 1 2; 1 2 2; 2 1 2; 2 2 2;
     1 1 3; 1 2 3; 2 1 3; 2 2 3
-    ]
+    ]'

--- a/test/test_coverage_set.jl
+++ b/test/test_coverage_set.jl
@@ -172,3 +172,55 @@ end
 ## multi_way_coverage
 mwc = UnitTestDesign.multi_way_coverage([2,3,4,2,2,3], Dict(3 => [[1,3,4,5]]), 2)
 @test maximum(sum(mwc .!= 0, dims = 1)) == 3
+
+
+#### Set-based
+
+### tuples_in_trials
+tt_cases = [
+    [[[1,2,3], [1,2,1], [2,3,4]], 2, 8],
+    [[[1,1,1], [1,1,1], [1,1,1]], 2, 3],
+    [[[1,1,1], [1,1,1], [1,1,1]], 3, 1],
+]
+for tt_case in tt_cases
+    res = UnitTestDesign.tuples_in_trials(tt_case[1], tt_case[2])
+    total_covered = sum([length(aset) for aset in values(res)])
+    @test total_covered == tt_case[3]
+end
+
+
+
+### n_way_coverage
+rng = Random.MersenneTwister(9234724)
+arity = [2,3,2,3]
+n_way = 2
+
+M = 50
+cover = n_way_coverage(arity, n_way, M, rng)
+tuple_cnt = UnitTestDesign.coverage_by_tuple(cover, n_way)
+@test tuple_cnt == UnitTestDesign.total_combinations(arity, n_way)
+
+n_way = 3
+cover = n_way_coverage(arity, n_way, M, rng)
+tuple_cnt = UnitTestDesign.coverage_by_tuple(cover, n_way)
+@test tuple_cnt == UnitTestDesign.total_combinations(arity, n_way)
+
+cover = n_way_coverage_init(arity, n_way, [], M, rng)
+tuple_cnt = UnitTestDesign.coverage_by_tuple(cover, n_way)
+@test tuple_cnt == UnitTestDesign.total_combinations(arity, n_way)
+
+rng = Random.MersenneTwister(9234724)
+arity = [2,3,2,3]
+n_way = 3
+
+M = 50
+seed = [
+    1 1 1 1;
+    1 3 1 1;
+    2 2 2 2;
+    2 1 2 1
+]
+cover = n_way_coverage_init(arity, n_way, seed, M, rng)
+tuple_cnt = UnitTestDesign.coverage_by_tuple(cover, n_way)
+# It is possible for this to fail randomly.
+@test tuple_cnt < UnitTestDesign.total_combinations(arity, n_way)

--- a/test/test_coverage_set.jl
+++ b/test/test_coverage_set.jl
@@ -4,12 +4,12 @@ using UnitTestDesign
 
 ### coverage_by_parameter
 cbp_cases = [
-    [[0 0 0; 0 0 0; 0 1 0], 3, [0, 1, 0]],
-    [[0 0 0; 0 0 0; 0 1 0], 2, [0, 0, 0]],
-    [[0 0 7; 0 0 4; 0 1 0], 3, [0, 1, 2]]
+    [[0 0 0; 0 0 0; 0 1 0]', 3, [0, 1, 0]],
+    [[0 0 0; 0 0 0; 0 1 0]', 2, [0, 0, 0]],
+    [[0 0 7; 0 0 4; 0 1 0]', 3, [0, 1, 2]]
 ]
 for cbp_case in cbp_cases
-    mc = UnitTestDesign.MatrixCoverage(cbp_case[1], cbp_case[2], [2, 2, 7])
+    mc = UnitTestDesign.MatrixCoverage(collect(cbp_case[1]), cbp_case[2], [2, 2, 7])
     res = UnitTestDesign.coverage_by_parameter(mc)
     @test res == cbp_case[3]
 end
@@ -24,22 +24,22 @@ mc_opcm = UnitTestDesign.one_parameter_combinations_matrix([2, 2, 3], 2)
 # (coverage matrix, remaining uncovered, arity,
 #  parameter, coverage of that parameter)
 cbv_cases = [
-    [[0 0 0; 0 0 0; 0 0 0], 3, [2,2,2], 1, [0, 0]],
-    [[0 0 0; 0 0 0; 0 0 0], 3, [2,2,2], 2, [0, 0]],
-    [[0 0 0; 0 0 0; 0 0 0], 3, [2,3,2], 2, [0, 0, 0]], # sees arity of choice
-    [[0 1 0; 0 1 0; 0 0 0], 3, [2,3,2], 2, [2, 0, 0]], # does multiple rows
-    [[0 1 0; 0 1 0; 0 3 0], 3, [2,3,2], 2, [2, 0, 1]], # does multiple columns
-    [[0 1 0; 0 1 0; 0 3 0], 2, [2,3,2], 2, [2, 0, 0]]  # excludes extra rows
+    [[0 0 0; 0 0 0; 0 0 0]', 3, [2,2,2], 1, [0, 0]],
+    [[0 0 0; 0 0 0; 0 0 0]', 3, [2,2,2], 2, [0, 0]],
+    [[0 0 0; 0 0 0; 0 0 0]', 3, [2,3,2], 2, [0, 0, 0]], # sees arity of choice
+    [[0 1 0; 0 1 0; 0 0 0]', 3, [2,3,2], 2, [2, 0, 0]], # does multiple rows
+    [[0 1 0; 0 1 0; 0 3 0]', 3, [2,3,2], 2, [2, 0, 1]], # does multiple columns
+    [[0 1 0; 0 1 0; 0 3 0]', 2, [2,3,2], 2, [2, 0, 0]]  # excludes extra rows
 ]
 for cbv_case in cbv_cases
-    mc = UnitTestDesign.MatrixCoverage(cbv_case[1], cbv_case[2], cbv_case[3])
+    mc = UnitTestDesign.MatrixCoverage(collect(cbv_case[1]), cbv_case[2], cbv_case[3])
     res = UnitTestDesign.coverage_by_value(mc, cbv_case[4])
     @test res == cbv_case[5]
 end
 
 
 ### most_matches_existing(allc, row_cnt, arity, existing, param_idx)
-mmm_allc = [1 1 1 0 0; 1 2 1 0 0; 0 0 1 2 2]
+mmm_allc = [1 1 1 0 0; 1 2 1 0 0; 0 0 1 2 2]'
 mmm_arity = [2, 2, 2, 2, 2]
 mmm_cases = [
     [[1, 0, 0, 0, 0], 2, [1, 1]],
@@ -55,7 +55,7 @@ mmm_cases = [
     [[0, 0, 1, 0, 2], 4, [0, 1]]
 ]
 for mmm_case in mmm_cases
-    mc = UnitTestDesign.MatrixCoverage(mmm_allc, 3, mmm_arity)
+    mc = UnitTestDesign.MatrixCoverage(collect(mmm_allc), 3, mmm_arity)
     res = UnitTestDesign.most_matches_existing(mc, mmm_case[1], mmm_case[2])
     @test res == mmm_case[3]
 end
@@ -68,15 +68,15 @@ arity4 = [3, 2, 2]
 allc4 = [
     1 0 1; 2 0 1; 3 0 1; 0 1 1; 0 2 1;
     1 0 2; 2 0 2; 3 0 2; 0 1 2; 0 2 2
-]
-mc4 = UnitTestDesign.MatrixCoverage(allc4, size(allc4, 1), arity4)
+]'
+mc4 = UnitTestDesign.MatrixCoverage(collect(allc4), size(allc4, 2), arity4)
 mm4 = UnitTestDesign.matches_from_missing(mc4, wider[1, :], 3)
 @test mm4 == [2, 2]
 
 ### first_match_for_parameter(mc, param_idx)
 arity = [3, 2, 2, 2]
-mat = [0 1 2 0; 2 2 1 0]
-mcfm = UnitTestDesign.MatrixCoverage(mat, size(mat, 1), arity)
+mat = [0 1 2 0; 2 2 1 0]'
+mcfm = UnitTestDesign.MatrixCoverage(collect(mat), size(mat, 2), arity)
 first = UnitTestDesign.first_match_for_parameter(mcfm, 3)
 @test first == [0, 1, 2, 0]
 blank = UnitTestDesign.first_match_for_parameter(mcfm, 1)
@@ -93,8 +93,8 @@ mat = [
     0 2 0;
     0 0 3;
     0 0 4
-]
-mc = UnitTestDesign.MatrixCoverage(mat, size(mat, 1), arity)
+]'
+mc = UnitTestDesign.MatrixCoverage(collect(mat), size(mat, 2), arity)
 res1 = UnitTestDesign.fill_consistent_matches(mc, [0, 2, 0])
 @test res1 == [1, 2, 3]
 
@@ -105,8 +105,8 @@ mat2 = [
     0 2 0;
     1 0 4;
     0 0 3
-]
-mc2 = UnitTestDesign.MatrixCoverage(mat2, size(mat2, 1), arity)
+]'
+mc2 = UnitTestDesign.MatrixCoverage(collect(mat2), size(mat2, 2), arity)
 res2 = UnitTestDesign.fill_consistent_matches(mc2, [0, 2, 0])
 @test res2 == [1, 2, 4]
 
@@ -117,8 +117,8 @@ mat3 = [
     0 2 0;
     0 0 3;
     1 0 4
-]
-mc3 = UnitTestDesign.MatrixCoverage(mat3, size(mat3, 1), arity)
+]'
+mc3 = UnitTestDesign.MatrixCoverage(collect(mat3), size(mat3, 2), arity)
 res3 = UnitTestDesign.fill_consistent_matches(mc3, [0, 2, 0])
 @test res3 == [1, 2, 3]
 
@@ -127,13 +127,13 @@ res3 = UnitTestDesign.fill_consistent_matches(mc3, [0, 2, 0])
 # when a new test covers values. It expects a particular
 # reordering due to swapping. Very much an implementation test.
 ac_cases = [
-    [[1 1 0; 1 2 0; 1 0 1; 1 0 2], 4, 2, [1, 1, 1], 2, [1 0 2; 1 2 0; 1 1 0; 1 0 1]],
-    [[1 1 0; 1 2 0; 1 0 1; 1 0 2], 3, 2, [1, 1, 1], 1, [1 2 0; 1 1 0; 1 0 1; 1 0 2]],
-    [[1 0 2; 0 2 2; 0 1 2], 1, 2, [1, 0, 2], 0, [1 0 2; 0 2 2; 0 1 2]],
-    [[1 0 2; 0 2 2; 0 1 2], 1, 2, [1, 0, 1], 1, [1 0 2; 0 2 2; 0 1 2]]
+    [[1 1 0; 1 2 0; 1 0 1; 1 0 2]', 4, 2, [1, 1, 1], 2, [1 0 2; 1 2 0; 1 1 0; 1 0 1]'],
+    [[1 1 0; 1 2 0; 1 0 1; 1 0 2]', 3, 2, [1, 1, 1], 1, [1 2 0; 1 1 0; 1 0 1; 1 0 2]'],
+    [[1 0 2; 0 2 2; 0 1 2]', 1, 2, [1, 0, 2], 0, [1 0 2; 0 2 2; 0 1 2]'],
+    [[1 0 2; 0 2 2; 0 1 2]', 1, 2, [1, 0, 1], 1, [1 0 2; 0 2 2; 0 1 2]']
 ]
 for ac_case in ac_cases
-    mcac = UnitTestDesign.MatrixCoverage(ac_case[1], ac_case[2], [2, 3, 2])
+    mcac = UnitTestDesign.MatrixCoverage(collect(ac_case[1]), ac_case[2], [2, 3, 2])
     UnitTestDesign.add_coverage!(mcac, ac_case[4])
     @test mcac.remain == ac_case[5]
     @test mcac.allc == ac_case[6]
@@ -142,14 +142,14 @@ end
 
 ### match_score
 ms_cases = [
-    [[1 1 0; 1 2 0; 0 1 3], 3, 2, [4,4,4], 0],
-    [[1 1 0; 1 2 0; 0 2 1; 0 1 3], 4, 2, [1,1,1], 1],
-    [[1 1 0; 1 2 0; 0 2 1; 0 1 3], 4, 2, [1,2,1], 2],
-    [[1 1 0; 1 2 0; 0 2 1; 0 1 3], 4, 2, [1,1,3], 2],
-    [[1 1 0; 1 2 0; 0 2 1; 0 1 3], 3, 2, [1,1,3], 1]
+    [[1 1 0; 1 2 0; 0 1 3]', 3, 2, [4,4,4], 0],
+    [[1 1 0; 1 2 0; 0 2 1; 0 1 3]', 4, 2, [1,1,1], 1],
+    [[1 1 0; 1 2 0; 0 2 1; 0 1 3]', 4, 2, [1,2,1], 2],
+    [[1 1 0; 1 2 0; 0 2 1; 0 1 3]', 4, 2, [1,1,3], 2],
+    [[1 1 0; 1 2 0; 0 2 1; 0 1 3]', 3, 2, [1,1,3], 1]
 ]
 for ms_case in ms_cases
-    mc_ms = UnitTestDesign.MatrixCoverage(ms_case[1], ms_case[2], [4, 4, 4])
+    mc_ms = UnitTestDesign.MatrixCoverage(collect(ms_case[1]), ms_case[2], [4, 4, 4])
     cnt = UnitTestDesign.match_score(mc_ms, ms_case[4])
     @test cnt == ms_case[5]
 end
@@ -157,24 +157,18 @@ end
 
 ## remove_combinations
 rc_cases = [
-    [[1 1 1; 1 1 2; 1 2 1; 1 2 2], (x -> x[2] == 1 && x[3] == 1), [1 1 2; 1 2 1; 1 2 2]],
-    [[1 1 1; 1 1 2; 1 2 1; 1 2 2], (x -> x[2] == 1), [1 2 1; 1 2 2]],
-    [[1 1 1; 1 1 2; 1 2 1; 1 2 2], (x -> x[1] == 1 && x[3] == 1), [1 1 2; 1 2 2]],
-    [[1 1 1; 1 1 2; 1 2 1; 1 2 2], (x -> x[2] < x[3]), [1 1 1; 1 2 1; 1 2 2]]
+    [[1 1 1; 1 1 2; 1 2 1; 1 2 2]', (x -> x[2] == 1 && x[3] == 1), [1 1 2; 1 2 1; 1 2 2]'],
+    [[1 1 1; 1 1 2; 1 2 1; 1 2 2]', (x -> x[2] == 1), [1 2 1; 1 2 2]'],
+    [[1 1 1; 1 1 2; 1 2 1; 1 2 2]', (x -> x[1] == 1 && x[3] == 1), [1 1 2; 1 2 2]'],
+    [[1 1 1; 1 1 2; 1 2 1; 1 2 2]', (x -> x[2] < x[3]), [1 1 1; 1 2 1; 1 2 2]']
 ]
 for rc_case in rc_cases
-    mc_rc = UnitTestDesign.MatrixCoverage(rc_case[1], 4, [2, 3, 2])
+    mc_rc = UnitTestDesign.MatrixCoverage(collect(rc_case[1]), 4, [2, 3, 2])
     UnitTestDesign.remove_combinations!(mc_rc, rc_case[2])
     @test mc_rc.allc == rc_case[3]
 end
 
 
-
-
-
-
-
-
 ## multi_way_coverage
-mwc = UnitTestDesign.multi_way_coverage([2,3,4,2,2,3], Dict(3 => [[1,4,4,5]]), 2)
-@test maximum(sum(mwc .!= 0, dims = 2)) == 3
+mwc = UnitTestDesign.multi_way_coverage([2,3,4,2,2,3], Dict(3 => [[1,3,4,5]]), 2)
+@test maximum(sum(mwc .!= 0, dims = 1)) == 3

--- a/test/test_greedy_tuples.jl
+++ b/test/test_greedy_tuples.jl
@@ -22,55 +22,6 @@ for ar_case in ar_cases
 end
 
 
-
-### tuples_in_trials
-tt_cases = [
-    [[[1,2,3], [1,2,1], [2,3,4]], 2, 8],
-    [[[1,1,1], [1,1,1], [1,1,1]], 2, 3],
-    [[[1,1,1], [1,1,1], [1,1,1]], 3, 1],
-]
-for tt_case in tt_cases
-    res = UnitTestDesign.tuples_in_trials(tt_case[1], tt_case[2])
-    total_covered = sum([length(aset) for aset in values(res)])
-    @test total_covered == tt_case[3]
-end
-
-
-### n_way_coverage
-rng = Random.MersenneTwister(9234724)
-arity = [2,3,2,3]
-n_way = 2
-
-M = 50
-cover = n_way_coverage(arity, n_way, M, rng)
-tuple_cnt = UnitTestDesign.coverage_by_tuple(cover, n_way)
-@test tuple_cnt == UnitTestDesign.total_combinations(arity, n_way)
-
-n_way = 3
-cover = n_way_coverage(arity, n_way, M, rng)
-tuple_cnt = UnitTestDesign.coverage_by_tuple(cover, n_way)
-@test tuple_cnt == UnitTestDesign.total_combinations(arity, n_way)
-
-cover = n_way_coverage_init(arity, n_way, [], M, rng)
-tuple_cnt = UnitTestDesign.coverage_by_tuple(cover, n_way)
-@test tuple_cnt == UnitTestDesign.total_combinations(arity, n_way)
-
-rng = Random.MersenneTwister(9234724)
-arity = [2,3,2,3]
-n_way = 3
-
-M = 50
-seed = [
-    1 1 1 1;
-    1 3 1 1;
-    2 2 2 2;
-    2 1 2 1
-]
-cover = n_way_coverage_init(arity, n_way, seed, M, rng)
-tuple_cnt = UnitTestDesign.coverage_by_tuple(cover, n_way)
-# It is possible for this to fail randomly.
-@test tuple_cnt < UnitTestDesign.total_combinations(arity, n_way)
-
 cover = n_way_coverage_filter(arity, n_way, x -> x[3] == 1 && x[4] != 1, [], M, rng)
 n_way_coverage([4,4,4,4,4,4,4,4,4], 2, M, rng)
 
@@ -82,7 +33,7 @@ arity = [2,3,4,2,2,3]
 n_way = 2
 high_indices = [1,3,4,5]
 mwc = UnitTestDesign.multi_way_coverage(arity, Dict(3 => [high_indices]), n_way)
-@test maximum(sum(mwc .!= 0, dims = 2)) == 3
+@test maximum(sum(mwc .!= 0, dims = 1)) == 3
 mc = UnitTestDesign.MatrixCoverage(mwc, size(mwc, 1), arity)
 cov = n_way_coverage_multi(mc, x->false, [], M, rng)
 cov_mat = vcat([cv' for cv in cov]...)

--- a/test/test_parameter_order.jl
+++ b/test/test_parameter_order.jl
@@ -1,7 +1,7 @@
 using UnitTestDesign
 ip232 = ipog([2, 3, 2], 2)
-@test size(ip232) == (6, 3)
+@test size(ip232) == (3, 6)
 ip2324 = ipog([2, 3, 2, 4, 7, 2], 2)
-@test size(ip2324) == (28, 6)
+@test size(ip2324) == (6, 28)
 
 #res = ipog([2, 3, 2, 4, 4, 4, 4, 4, 4, 4, 4, 7, 2, 4, 5, 4, 4], 3)


### PR DESCRIPTION
The arrays were flipped col-row from where they should be for efficiency. This is standard stuff. I followed the papers without thinking about Julia being in Fortran-order. This flips all of them and ensures all tests run.