### PR TITLE
Feature/pull apart ipog

### DIFF
--- a/src/parameter_order.jl
+++ b/src/parameter_order.jl
@@ -192,47 +192,6 @@ function ipog(arity, n_way)
 end
 
 
-function ipog_instrumented(arity, n_way, strategy)
-    nonincreasing = sortperm(arity, rev = true)
-    original_arity = arity
-    arity = arity[nonincreasing]
-    original_order = sortperm(nonincreasing)
-
-    param_cnt = length(arity)
-    widen = zeros(Int, param_cnt)
-    fillz = zeros(Int, param_cnt)
-    cover = zeros(Int, param_cnt)
-    # Setup by taking first n_way parameters.
-    # This is a 2D array.
-    test_set = all_combinations(arity[1:n_way], n_way)
-
-    for param_idx in (n_way + 1):param_cnt
-        taller = zeros(eltype(arity), param_idx, size(test_set, 2))
-        taller[1:(param_idx - 1), :] .= test_set
-
-        allc = choose_last_parameter!(taller, arity, n_way, strategy[:lastparam])
-        widen[param_idx] = size(allc.allc, 2) - allc.remain
-
-        fill_missing_test_set_values!(taller, allc, strategy[:missingvals])
-        fillz[param_idx] = size(allc.allc, 2) - allc.remain - widen[param_idx]
-
-        add_entries = cover_remaining_by_creating_cases(allc, strategy[:expand])
-        cover[param_idx] = length(add_entries)
-
-        test_set = zeros(eltype(arity), param_idx, size(taller, 2) + length(add_entries))
-        test_set[:, 1:size(taller, 2)] .= taller
-        for long_idx in 1:length(add_entries)
-            test_set[:, size(taller, 2) + long_idx] .= add_entries[long_idx]
-        end
-    end
-
-    # remove the part to fill missing values at the end.
-
-    # reorder test columns with `original_order`.
-    (test_set[original_order, :], widen, fillz, cover)
-end
-
-
 function ipog_bytuple_instrumented(arity, n_way, strategy)
     nonincreasing = sortperm(arity, rev = true)
     original_arity = arity

--- a/test/nonfunctional.jl
+++ b/test/nonfunctional.jl
@@ -27,7 +27,7 @@ function single_test!(test_case, rng)
     arity = zeros(test_case.k, test_case.n)
     fill!(arity, test_case.r)
     callee = fut_map[test_case.fut]
-    @timed callee(arity, wayness, test_case.M, rng)
+    @timed callee(arity, test_case.wayness, test_case.M, rng)
 end
 
 
@@ -79,12 +79,12 @@ calvagna_table4 = DataFrame(
     cases = [47, 169, 361, 618, 956, 1355]
 )
 N = 5
-calvagna_table4 = DataFrame(
-    n = fill(3, N),
-    r = [3, 4, 5, 6, 7],
-    wayness = fill(2, N)
-    cases = [9, 9, 9, 9, 10, 9]
-)
+# calvagna_table4 = DataFrame(
+#     n = fill(3, N),
+#     r = [3, 4, 5, 6, 7],
+#     wayness = fill(2, N),
+#     cases = [9, 9, 9, 9, 10, 9]
+# )
 
 
 N = 10
@@ -195,7 +195,7 @@ push!(cases, DataFrame(
 
 df = vcat(cases...)
 rng = MersenneTwister(947234)
-test_against_cases!(df, 30, rng)
+test_against_cases!(df, 10, rng)
 df
 
 CSV.write("nonfunctional_cases_$(today()).csv", df)

--- a/test/nonfunctional.jl
+++ b/test/nonfunctional.jl
@@ -183,11 +183,10 @@ match_options = [
     UnitTestDesign.case_partial_cover,
     UnitTestDesign.case_covers_tuple
 ]
-opt_cnt = length(match_options)^length(match_options)
+opt_cnt = length(match_options)^3
 opt_res = zeros(Int, 4, opt_cnt)
 for opt_choice in 1:opt_cnt
     strat_idx = digits(opt_choice - 1, base = 3, pad = 3) .+ 1
-    strat_idx = [1, 1, 2]
     if strat_idx[1] != 3
         strategy = Dict((a, match_options[b]) for (a, b) in
             zip([:lastparam, :missingvals, :expand], strat_idx))
@@ -197,3 +196,29 @@ for opt_choice in 1:opt_cnt
     end
 end
 opt_res
+
+
+match_options = [
+    UnitTestDesign.case_compatible_with_tuple,
+    UnitTestDesign.case_partial_cover,
+    UnitTestDesign.case_covers_tuple
+]
+strat_cnt = 2
+opt_cnt = length(match_options)^strat_cnt
+opt_res = zeros(Int, 1 + strat_cnt, opt_cnt)
+for opt_choice in 1:opt_cnt
+    strat_idx = digits(opt_choice - 1, base = 3, pad = strat_cnt) .+ 1
+    if strat_idx[1] != 3
+        strategy = Dict((a, match_options[b]) for (a, b) in
+            zip([:lastparam, :expand], strat_idx))
+
+        ret = UnitTestDesign.ipog_bytuple_instrumented(fill(4, 20), 2, strategy)
+        opt_res[:, opt_choice] = vcat(size(ret[1], 2), strat_idx)
+    end
+end
+opt_res
+
+strat_idx = [2, 1]
+strategy = Dict((a, match_options[b]) for (a, b) in
+    zip([:lastparam, :expand], strat_idx))
+ret = UnitTestDesign.ipog_bytuple_instrumented(fill(4, 30), 2, strategy)

--- a/test/test_coverage_set.jl
+++ b/test/test_coverage_set.jl
@@ -60,6 +60,27 @@ for mmm_case in mmm_cases
     @test res == mmm_case[3]
 end
 
+# Let's understand this most_matches_existing function by assuming,
+# at this point, that it obeys the condition that the given parameter
+# index must be nonzero. Let's always put that last. And let's just make
+# one row to cover or not cover. Test for yes or no.
+mm2_arity = [2, 2, 2, 2]
+# test is a) a tuple to cover, b) an existing array. The param_idx is the last entry,
+# so that's always zero for the "existing" array.
+mm2_cases = [
+    [[1; 1; 0; 1], [1, 1, 0, 0], 1],
+    [[1; 1; 0; 1], [1, 0, 0, 0], 1],
+    [[1; 1; 0; 1], [0, 0, 0, 0], 1],
+    [[1; 1; 0; 1], [1, 0, 2, 0], 0],  # This could be a 1. This is subtle. Must match all existing.
+    [[1; 1; 0; 1], [1, 1, 2, 0], 0]   # again, compatible but not exact.
+]
+for mm2_case in mm2_cases
+    mc = UnitTestDesign.MatrixCoverage(reshape(mm2_case[1], length(mm2_arity), 1), 1, mm2_arity)
+    res = UnitTestDesign.most_matches_existing(mc, mm2_case[2], length(mm2_arity))
+    @test res == [mm2_case[3], 0]
+end
+
+
 wider = [
     1 1 0; 1 2 0; 2 1 0;
     2 2 0; 3 1 0; 3 2 0

--- a/test/test_coverage_set.jl
+++ b/test/test_coverage_set.jl
@@ -147,7 +147,7 @@ allc = UnitTestDesign.MatrixCoverage(
     3,
     [2, 3, 3]
 )
-insert_tuple_into_tests(test_set, allc)
+UnitTestDesign.insert_tuple_into_tests(test_set, allc)
 
 
 wider = [


### PR DESCRIPTION
This rewrites the in-parameter-order algorithm. Testing showed the original version yielded too many tuples. This reduces the number of tuples to what we expect. There was a subtle difference in the algorithm. Hint: Don't do what the easy-to-follow directions tell you. Do what the hard-to-follow paper says to do.