### PR TITLE
Make MatrixCoverage{Int} a concrete type

### DIFF
--- a/src/coverage_matrix.jl
+++ b/src/coverage_matrix.jl
@@ -26,7 +26,7 @@ to understand the interface to the data structure.
 """
 mutable struct MatrixCoverage{T <: Integer}
     allc::Array{T, 2}
-    remain::Integer
+    remain::T
     arity::Array{T, 1}
 end
 


### PR DESCRIPTION
This PR results in a 7x performance improvement on this use case due to eliminating some runtime dispatch.
```julia
julia> @elapsed for _ in 1:30 all_pairs(rand.((30, 18, 9, 2, 6, 3, 5))...) end
6.461240745 # bfore
0.878610926 # after
```
See https://docs.julialang.org/en/v1/manual/performance-tips/#Avoid-fields-with-abstract-type for why this change has such a big performance impact.