### PR TITLE
Feature/vscode tests

### DIFF
--- a/test/test_combinations.jl
+++ b/test/test_combinations.jl
@@ -43,10 +43,13 @@ end
 end
 
 
-@testitem "All combinations" begin
+@testitem "All combinations" setup=[UTSetup] begin
     using Random
-    rng = Xoshiro(9237425)
-    for ac_trial_idx in 1:5
+    rng = Xoshiro(9237425 ⊻ seed_mod())
+    test_time = 30 * test_run_multiplier()
+
+    start_time = time()
+    while time() - start_time < test_time
         n_way = [2, 3, 4][rand(rng, 1:3)]
         param_cnt = rand(rng, (n_way + 1):(n_way + 3))
         arity = rand(rng, 2:4, param_cnt)

--- a/test/test_coverage_matrix.jl
+++ b/test/test_coverage_matrix.jl
@@ -74,7 +74,6 @@ end
 
 
 @testitem "coverage_by_value" begin
-
     # (coverage matrix, remaining uncovered, arity,
     #  parameter, coverage of that parameter)
     cbv_cases = [
@@ -205,6 +204,7 @@ end
     @test res1 == [1, 2, 3]
 end
 
+
 @testitem "fill_consistent_matches incrmental change" begin
     arity = [2, 4, 4]
     mat2 = [
@@ -219,6 +219,7 @@ end
     @test res2 == [1, 2, 4]
 end
 
+
 @testitem "fill_consistent_matches another increment" begin
     arity = [2, 4, 4]
     mat3 = [
@@ -232,6 +233,7 @@ end
     res3 = UnitTestDesign.fill_consistent_matches(mc3, [0, 2, 0])
     @test res3 == [1, 2, 3]
 end
+
 
 @testitem "add_coverage!(allc, row_cnt, entry)" begin
     # This checks that the rows of the matrix are reordered

--- a/test/test_excursions.jl
+++ b/test/test_excursions.jl
@@ -1,6 +1,7 @@
 using Test
 using TestItemRunner
 
+
 @testitem "arity excursion with an exclusion" begin
     be1_arity = [2, 3, 2, 4]
     be1_res = UnitTestDesign.build_excursion(be1_arity, 2, x -> false)

--- a/test/test_factorial_interface.jl
+++ b/test/test_factorial_interface.jl
@@ -1,7 +1,6 @@
 using Test
 using TestItemRunner
 
-### wrap_disallow, an internal function.
 
 @testitem "wrap_disallow" begin
 
@@ -27,7 +26,6 @@ using TestItemRunner
     @inferred UnitTestDesign.wrap_disallow(filter_bc, params)
 end
 
-## seeds_to_integers, an internal function
 
 @testitem "seeds_to_integers" begin
 
@@ -38,14 +36,12 @@ end
 
 end
 
-## IPOG
 
 @testitem "IPOG init" begin
     ipog = IPOG()
     @test isa(ipog, IPOG)
 end
 
-## GND
 
 @testitem "GND init" begin
     using Random
@@ -68,7 +64,6 @@ end
     @test randn(gnd5.rng) == sample3
 end
 
-## generate_tuples(IPOG())
 
 @testitem "IPOG generate tuples" begin
     trials1 = generate_tuples(IPOG(), 2, ([1, 2], [true, false], ["a", "b", "c"]),
@@ -111,6 +106,7 @@ end
         nothing, nothing, nothing, Int8)
     @test length(trials6) == 6
 end
+
 
 @testitem "GND generate tuples" begin
     gndt1 = generate_tuples(GND(), 2, ([1, 2], [true, false], ["a", "b", "c"]),
@@ -155,24 +151,24 @@ end
     @test length(trials6) == 6
 end
 
-## all_values
-@testitem "IPOG generate tuples" begin
+
+@testitem "IPOG generate all values" begin
     av1 = all_values([1, 2], ["a", "b", "c"], [4, 7])
     @test length(av1) == 3
     @test av1[1][3] in [4, 7]
 
 end
 
-## all_pairs
-@testitem "IPOG generate tuples" begin
+
+@testitem "IPOG generate all pairs" begin
     pairs1 = all_pairs([1, 2], ["a", "b", "c"], [4, 7])
     @test length(pairs1) > 3
     @test pairs1[1][3] in [4, 7]
 
 end
 
-## all_triples
-@testitem "IPOG generate tuples" begin
+
+@testitem "IPOG generate all triples" begin
     at1 = all_triples([1, 2], ["a", "b", "c"], [4, 7], [true, false])
     @test length(at1) > 9
     @test at1[1][3] in [4, 7]

--- a/test/test_greedy_tuples.jl
+++ b/test/test_greedy_tuples.jl
@@ -2,7 +2,7 @@ using Test
 using TestItemRunner
 
 
-@testitem "argmin_rand" begin
+@testitem "argmin_rand" setup=[UTSetup] begin
     using Random
     ar_cases = [
         [[1,2,3,1,4], [1,4]],
@@ -10,7 +10,7 @@ using TestItemRunner
         [[0, -1, -2, -2], [3, 4]],
         [[1,1,1,1], [1,2,3,4]]
     ]
-    ar_rng = Xoshiro(342234)
+    ar_rng = Xoshiro(342234 ⊻ seed_mod())
     for ar_case in ar_cases
         values = Set{Int}()
         for i in 1:100
@@ -23,23 +23,30 @@ using TestItemRunner
 end
 
 
-@testitem "n way coverage with filter" begin
-    using Random
-    n_way = 2
-    M = 50
-    rng = Xoshiro(97072343)
-    arity = [5, 4, 3, 2, 2]
-    cover = UnitTestDesign.n_way_coverage_filter(arity, n_way, x -> x[3] == 1 && x[4] != 1, [], M, rng)
-    nn = UnitTestDesign.n_way_coverage([4,4,4,4,4,4,4,4,4], 2, M, rng)
-    @test length(nn) > 20
-    @test length(nn) < 100
-    @inferred UnitTestDesign.n_way_coverage([4,4,4,4,4,4,4,4,4], 2, M, rng)
+@testitem "n way coverage with filter" setup=[UTSetup] begin
+    rng = Xoshiro(97072343 ⊻ seed_mod())
+    test_time = 10 * test_run_multiplier()
+    start_time = time()
+    while time() - start_time < test_time
+        n_way = 2
+        M = 50
+        arity = [5, 4, 3, 2, 2]
+        cover = @inferred UnitTestDesign.n_way_coverage_filter(
+            arity, n_way,
+            x -> x[3] == 1 && x[4] != 1,
+            [],
+            M,
+            rng
+            )
+        nn = UnitTestDesign.n_way_coverage([4,4,4,4,4,4,4,4,4], 2, M, rng)
+        @test length(nn) > 20
+        @test length(nn) < 100
+    end
 end
 
 
-@testitem "n_way_coverage_multi" begin
-    using Random
-    rng = Xoshiro(789607)
+@testitem "n_way_coverage_multi" setup=[UTSetup] begin
+    rng = Xoshiro(789607 ⊻ seed_mod())
     M = 50
     arity = [2,3,4,2,2,3]
     n_way = 2
@@ -61,45 +68,53 @@ end
 end
 
 
-@testitem "n_way_coverage" begin
+@testitem "n_way_coverage" setup=[UTSetup] begin
     using Random
-    rng = Xoshiro(9234724)
-    arity = [2,3,2,3]
-    n_way = 2
+    rng = Xoshiro(9234724 ⊻ seed_mod())
+    test_time = 10 * test_run_multiplier()
 
-    M = 50
-    cover = UnitTestDesign.n_way_coverage(arity, n_way, M, rng)
-    tuple_cnt = UnitTestDesign.coverage_by_tuple(cover, n_way)
-    @test tuple_cnt == UnitTestDesign.total_combinations(arity, n_way)
+    start_time = time()
+    while time() - start_time < test_time
+        arity = [2,3,2,3]
+        n_way = 2
+        M = 50
+        cover = UnitTestDesign.n_way_coverage(arity, n_way, M, rng)
+        tuple_cnt = UnitTestDesign.coverage_by_tuple(cover, n_way)
+        @test tuple_cnt == UnitTestDesign.total_combinations(arity, n_way)
 
-    n_way = 3
-    cover = UnitTestDesign.n_way_coverage(arity, n_way, M, rng)
-    tuple_cnt = UnitTestDesign.coverage_by_tuple(cover, n_way)
-    @test tuple_cnt == UnitTestDesign.total_combinations(arity, n_way)
+        n_way = 3
+        cover = UnitTestDesign.n_way_coverage(arity, n_way, M, rng)
+        tuple_cnt = UnitTestDesign.coverage_by_tuple(cover, n_way)
+        @test tuple_cnt == UnitTestDesign.total_combinations(arity, n_way)
 
-    cover = UnitTestDesign.n_way_coverage_init(arity, n_way, zeros(length(arity), 0), M, rng)
-    tuple_cnt = UnitTestDesign.coverage_by_tuple(cover, n_way)
-    @test tuple_cnt == UnitTestDesign.total_combinations(arity, n_way)
+        cover = UnitTestDesign.n_way_coverage_init(arity, n_way, zeros(length(arity), 0), M, rng)
+        tuple_cnt = UnitTestDesign.coverage_by_tuple(cover, n_way)
+        @test tuple_cnt == UnitTestDesign.total_combinations(arity, n_way)
+    end
 end
 
 
-@testitem "coverage by tuple" begin
+@testitem "coverage by tuple" setup=[UTSetup] begin
     using Random
-    rng = Xoshiro(9234724)
-    arity = [2,3,2,3]
-    n_way = 3
-
-    M = 50
-    seed = [
-        1 1 1 1;
-        1 3 1 1;
-        2 2 2 2;
-        2 1 2 1
-    ]
-    cover = UnitTestDesign.n_way_coverage_init(arity, n_way, seed, M, rng)
-    tuple_cnt = UnitTestDesign.coverage_by_tuple(cover, n_way)
-    # It is possible for this to fail randomly.
-    for sti in 1:size(seed, 2)
-        @test seed[:, sti] in cover
+    rng = Xoshiro(923424323 ⊻ seed_mod())
+    test_time = 10 * test_run_multiplier()
+    
+    start_time = time()
+    while time() - start_time < test_time
+        arity = [2,3,2,3]
+        n_way = 3
+        M = 50
+        seed = [
+            1 1 1 1;
+            1 3 1 1;
+            2 2 2 2;
+            2 1 2 1
+        ]
+        cover = UnitTestDesign.n_way_coverage_init(arity, n_way, seed, M, rng)
+        tuple_cnt = UnitTestDesign.coverage_by_tuple(cover, n_way)
+        # It is possible for this to fail randomly.
+        for sti in 1:size(seed, 2)
+            @test seed[:, sti] in cover
+        end
     end
 end

--- a/test/test_parameter_order.jl
+++ b/test/test_parameter_order.jl
@@ -19,6 +19,7 @@ end
     @test UnitTestDesign.test_coverage(im232, [2, 3, 2], 2) == (start = 16, finish = 0)
 end
 
+
 @testitem "ipog multi with seed and exclusion" begin
     seed232 = [2 1; 3 3; 1 2]
     is232 = UnitTestDesign.ipog_multi([2, 3, 2], 2, x -> false, seed232)


### PR DESCRIPTION
Fixes a problem where tests didn't run from the GUI in VisualStudio Code because that GUI adds commandline arguments when it calls runtests.jl. This now detects those arguments and stops ArgParse processing. Also updated formatting.